### PR TITLE
Evaluate CLI arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "cargo-doc-gen"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "num_cpus",
  "syn",
 ]
 
@@ -63,6 +64,16 @@ name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33"
+num_cpus = "1.13.0"
 syn = { version = "1.0", features = ["full"] }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,13 +13,13 @@ pub fn parse<'a>() -> ArgMatches<'a> {
             Arg::with_name("check")
                 .short("c")
                 .long("check")
-                .help("Validate existing documentation"),
+                .help("Validates existing documentation"),
         )
         .arg(
             Arg::with_name("threads")
                 .short("t")
                 .long("threads")
-                .help("Maximum number of threads to use")
+                .help("Sets the maximum number of threads to use")
                 .takes_value(true)
                 .validator(|s| {
                     s.parse::<usize>()

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,13 @@ fn main() {
         .and_then(|value| value.parse().ok())
         .unwrap_or_else(num_cpus::get);
 
-    let run = if args.is_present("check") {
+    let try_run = if args.is_present("check") {
         try_validate
     } else {
         try_generate
     };
 
-    if let Err(e) = run(max_threads) {
+    if let Err(e) = try_run(max_threads) {
         eprintln!("{}", e);
         std::process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use std::error::Error;
 use std::result::Result;
 
-use clap::ArgMatches;
-
 mod ast;
 mod check;
 mod cli;
@@ -14,12 +12,33 @@ mod doc_tree;
 
 fn main() {
     let args = cli::parse();
-    if let Err(e) = try_run(args) {
+
+    // TODO(#19) check for the existence of the config file.
+    // TODO(#3) deserialize config file.
+
+    let max_threads = args
+        .value_of("threads")
+        .and_then(|value| value.parse().ok())
+        .unwrap_or_else(num_cpus::get);
+
+    let run = if args.is_present("check") {
+        try_validate
+    } else {
+        try_generate
+    };
+
+    if let Err(e) = run(max_threads) {
         eprintln!("{}", e);
         std::process::exit(1);
     }
 }
 
-fn try_run(_args: ArgMatches) -> Result<(), Box<dyn Error>> {
-    Err("The program logic is not yet implemented.".into())
+// TODO(#3) pass DocConfig as an argument.
+fn try_generate(_max_threads: usize) -> Result<(), Box<dyn Error>> {
+    Err("Documentation generation is not implemented yet".into())
+}
+
+// TODO(#3) pass DocConfig as an argument.
+fn try_validate(_max_threads: usize) -> Result<(), Box<dyn Error>> {
+    Err("Documentation validation is not implemented yet".into())
 }


### PR DESCRIPTION
Evaluates the arguments that are passed in through the CLI.

Makes a minor update to the wording of the help message to keep things similar to what Clippy auto-generates. 