### PR TITLE
Remove authors from help text

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,6 @@ use clap::{App, Arg, ArgMatches};
 pub fn parse<'a>() -> ArgMatches<'a> {
     let app = App::new(clap::crate_name!())
         .version(clap::crate_version!())
-        .author(clap::crate_authors!(", "))
         .about(clap::crate_description!())
         .arg(
             Arg::with_name("check")


### PR DESCRIPTION
It's unnecessary to have author names and emails in help text.